### PR TITLE
Feature/docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.log
 /.vagrant/
 /.idea/
+/certs/
 /config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Docker image to use with Vagrant
+# Adapted from https://github.com/BashtonLtd/docker-vagrant-images/blob/master/ubuntu1404/Dockerfile
+
+# Define the base environment
+FROM ubuntu:20.04
+ENV container docker
+
+# Install system dependencies
+RUN apt-get update -y && apt-get dist-upgrade -y
+RUN apt-get install -y --no-install-recommends ssh sudo systemd openssh-client puppet
+
+# Add vagrant user and key for SSH
+RUN useradd --create-home -s /bin/bash vagrant
+RUN echo -n 'vagrant:vagrant' | chpasswd
+RUN echo 'vagrant ALL = NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+RUN chmod 440 /etc/sudoers.d/vagrant
+RUN mkdir -p /home/vagrant/.ssh
+RUN chmod 700 /home/vagrant/.ssh
+RUN echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==" > /home/vagrant/.ssh/authorized_keys
+RUN chmod 600 /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant:vagrant /home/vagrant/.ssh
+RUN sed -i -e 's/Defaults.*requiretty/#&/' /etc/sudoers
+RUN sed -i -e 's/\(UsePAM \)yes/\1 no/' /etc/ssh/sshd_config
+
+# Start SSH
+RUN mkdir /var/run/sshd
+EXPOSE 22
+RUN /usr/sbin/sshd
+
+# Allow connection to the web server
+EXPOSE 80
+EXPOSE 443
+
+# Start Systemd (systemctl)
+CMD ["/lib/systemd/systemd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y --no-install-recommends ssh sudo systemd openssh-client p
 # Add vagrant user and key for SSH
 RUN useradd --create-home -s /bin/bash vagrant
 RUN echo -n 'vagrant:vagrant' | chpasswd
-RUN echo 'vagrant ALL = NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
 RUN chmod 440 /etc/sudoers.d/vagrant
 RUN mkdir -p /home/vagrant/.ssh
 RUN chmod 700 /home/vagrant/.ssh


### PR DESCRIPTION
Add support for Docker as the VM provider.

Requirements:
- Docker must be installed
- the domain names mentioned in the config file must all target `127.0.0.1`

Particularities:
The networking is not managed the same by Docker, and the IP address configured by Vagrant is not reachable. To workaround this, it is simplified and the IP address of the Vagrant machine will always fallback to 127.0.0.1 with port forwarding.
The resources management is also not applied (disk size, memory, CPU), nor the mount options applied for the shared disks as Docket does not support it.
There is no base image too, so that the config can be simplified.

How to test:
- copy the `config-dist.yaml` file to `config.yaml`, and set the provider to `docker`
- configure the path to your root project
- set the right DNS
- run `vagrant up`
- try to access the machine
