### PR TITLE
Feature/update composer

### DIFF
--- a/cookbooks/composer/attributes/default.rb
+++ b/cookbooks/composer/attributes/default.rb
@@ -1,0 +1,19 @@
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; under version 2
+# of the License (non-upgradable).
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
+#
+
+default["composer"]["bin"] = "/usr/local/bin/composer"

--- a/cookbooks/composer/recipes/default.rb
+++ b/cookbooks/composer/recipes/default.rb
@@ -13,15 +13,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+# Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
 #
 
-if not package_installed?("composer")
-    # install Composer using aptitude
-    install_packages_once [ "composer" ]
-
-    # additional plugins
-    execute "composer global require hirak/prestissimo"
+if not File.exist?("composer")
+    # install Composer using the installer
+    execute_template("install.erb", {
+        :bin => node["composer"]["bin"],
+    }, "composer")
 
     # configure default
     home = Dir.home(get_user)

--- a/cookbooks/composer/recipes/default.rb
+++ b/cookbooks/composer/recipes/default.rb
@@ -16,7 +16,7 @@
 # Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
 #
 
-if not File.exist?("composer")
+if not File.exist?(node["composer"]["bin"])
     # install Composer using the installer
     execute_template("install.erb", {
         :bin => node["composer"]["bin"],

--- a/cookbooks/composer/templates/default/install.erb
+++ b/cookbooks/composer/templates/default/install.erb
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# taken from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+#
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+# added to place composer at a shared place
+sudo mv composer.phar <%= @bin %>
+# end added
+exit $RESULT


### PR DESCRIPTION
Rework the cookbook for Composer, using an install script instead of Aptitude.
The default package was still installing version 1. The install script always takes the last version.