### PR TITLE
Fix/PHP Redis

### DIFF
--- a/cookbooks/php/recipes/default.rb
+++ b/cookbooks/php/recipes/default.rb
@@ -13,7 +13,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+# Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA;
 #
 
 php_version = node["php"]["version"]
@@ -55,12 +55,12 @@ if php_version != installed_version
         "php#{php_version}-xsl",
         "php#{php_version}-mbstring",
         "php#{php_version}-zip",
+        "php#{php_version}-redis",
         "php-apcu",
         "php-pear",
         "php-imagick",
         "php-memcache",
-        "php-gettext",
-        "php-redis"
+        "php-gettext"
     ]
     install_packages_once php_packages
 


### PR DESCRIPTION
Install the correct version of php-redis.

It was installing a default version, and the link was not made to the correct PHP version.
This was visible by looking at the [php-config](https://github.com/oat-sa/vagrant-sandbox/blob/ca5a8641e6427e86b678182514f4244e4c51f775/cookbooks/php/recipes/default.rb#L82) file. The targeted folder didn't contain the `redis.so` module.